### PR TITLE
Fixed tile bug and collision

### DIFF
--- a/Food boy saves the kitchen/Assets/Scripts/Coordinator.cs
+++ b/Food boy saves the kitchen/Assets/Scripts/Coordinator.cs
@@ -71,7 +71,7 @@ public class Coordinator : MonoBehaviour
         {
             foreach (TileManager tile in tiles)
             {
-                tile.TriggerTile();
+                tile.TriggerTile(); //update collider
             }
 
             //At this point, moved to new, oldCol is the one to reenable.
@@ -94,13 +94,24 @@ public class Coordinator : MonoBehaviour
                     /* Enable hot/cold and heavy again for food 
                      * items going out of tile
                      */
-                    tile.ActivateDormantProperties(hotCold, heavyTiles);
+                    tile.ActivateDormantHotCold(hotCold);
                 }
   
                 //You, cold and hot tile tag + updates in case change of objects
                 foreach (TileManager tile in tiles)
                 {
                     tile.OldColUpdate(); //run all old col updates before new ones.
+                }
+
+                foreach (WinManager winTile in winTiles)
+                {
+                    winTile.ExitTrigger();
+                }
+                
+                //Tag updates for new objects that stepped into different tiles
+                foreach (WinManager winTile in winTiles)
+                {
+                    winTile.EnterTrigger();
                 }
 
                 foreach (TileManager tile in tiles)
@@ -111,12 +122,12 @@ public class Coordinator : MonoBehaviour
                 //Deactivate objects if both hot and cold.
                 foreach (TileManager tile in tiles)
                 {
-                    tile.DeactivateDormantProperties(hotCold);
+                    tile.DeactivateDormantHotCold(hotCold);
                 }
             }
 
             HeavyActivation();
-            SpriteUpdate();
+            SpriteUpdate(); //deactivates gameobject if tags are appropriate.
 
             //Win tile updates
             executeWinManagers();
@@ -258,6 +269,7 @@ public class Coordinator : MonoBehaviour
 
             var list = new List<KeyValuePair<PlayerManager, Vector3>>();
             //Allow players that are not children to update their destination.
+
             foreach (GameObject player in players)
             {
                 if (Mathf.Abs(horizontalMove) == 1f && timer.countdownFinished() && !player.GetComponent<Tags>().isInAnyTile())

--- a/Food boy saves the kitchen/Assets/Scripts/Tags.cs
+++ b/Food boy saves the kitchen/Assets/Scripts/Tags.cs
@@ -236,4 +236,23 @@ public class Tags : MonoBehaviour
          */
         objectTags = tags;
     }
+
+    public void printTags()
+    {
+        /* Prints out the tags for debugging purposes.
+         */
+        Debug.Log("1) Is player " + objectTags[0] +
+                  "\n2) Part of winTile " + objectTags[1] +
+                  "\n3) Part of youTile " + objectTags[2] +
+                  "\n4) Part of hotTile " + objectTags[3] +
+                  "\n5) Part of coldTile " + objectTags[4] +
+                  "\n6) Part of heavyTile " + objectTags[5] +
+                  "\n7) Is heavy " + objectTags[6] +
+                  "\n8) Is sharp " + objectTags[7] +
+                  "\n9) Is cut " + objectTags[8] +
+                  "\n10) Is hot " + objectTags[9] +
+                  "\n11) Is cold " + objectTags[10] +
+                  "\n12) Is cooked " + objectTags[11] +
+                  "\n13) Is inactive " + objectTags[12]);
+    }
 }

--- a/Food boy saves the kitchen/UserSettings/Layouts/default-2021.dwlt
+++ b/Food boy saves the kitchen/UserSettings/Layouts/default-2021.dwlt
@@ -120,7 +120,7 @@ MonoBehaviour:
   m_MinSize: {x: 400, y: 200}
   m_MaxSize: {x: 32384, y: 16192}
   vertical: 0
-  controlID: 158
+  controlID: 162
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -140,12 +140,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 348
+    width: 346
     height: 579.3333
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 113
+  controlID: 115
 --- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -165,12 +165,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 348
+    width: 346
     height: 290
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 114
+  controlID: 116
 --- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -188,7 +188,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 166.66667
+    width: 166
     height: 290
   m_MinSize: {x: 231, y: 271}
   m_MaxSize: {x: 10001, y: 10021}
@@ -212,12 +212,12 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 166.66667
+    x: 166
     y: 0
-    width: 181.33333
+    width: 180
     height: 290
-  m_MinSize: {x: 200, y: 200}
-  m_MaxSize: {x: 4000, y: 4000}
+  m_MinSize: {x: 202, y: 221}
+  m_MaxSize: {x: 4002, y: 4021}
   m_ActualView: {fileID: 17}
   m_Panes:
   - {fileID: 17}
@@ -240,10 +240,10 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 290
-    width: 348
+    width: 346
     height: 289.3333
-  m_MinSize: {x: 100, y: 100}
-  m_MaxSize: {x: 4000, y: 4000}
+  m_MinSize: {x: 101, y: 121}
+  m_MaxSize: {x: 4001, y: 4021}
   m_ActualView: {fileID: 18}
   m_Panes:
   - {fileID: 18}
@@ -266,14 +266,14 @@ MonoBehaviour:
   - {fileID: 13}
   m_Position:
     serializedVersion: 2
-    x: 348
+    x: 346
     y: 0
-    width: 676.6666
+    width: 678.6666
     height: 579.3333
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 159
+  controlID: 45
 --- !u!114 &12
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -291,7 +291,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 676.6666
+    width: 678.6666
     height: 333.33334
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
@@ -317,7 +317,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 333.33334
-    width: 676.6666
+    width: 678.6666
     height: 245.99997
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
@@ -346,8 +346,8 @@ MonoBehaviour:
     y: 0
     width: 255.33337
     height: 579.3333
-  m_MinSize: {x: 275, y: 100}
-  m_MaxSize: {x: 4000, y: 4000}
+  m_MinSize: {x: 276, y: 121}
+  m_MaxSize: {x: 4001, y: 4021}
   m_ActualView: {fileID: 21}
   m_Panes:
   - {fileID: 21}
@@ -373,9 +373,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 348
+    x: 346
     y: 406
-    width: 674.6666
+    width: 676.6666
     height: 224.99997
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -389,7 +389,7 @@ MonoBehaviour:
   m_ShowGizmos: 0
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
-  m_TargetSize: {x: 1011.99994, y: 305.99994}
+  m_TargetSize: {x: 1014.99994, y: 305.99994}
   m_TextureFilterMode: 0
   m_TextureHideFlags: 61
   m_RenderIMGUI: 1
@@ -404,8 +404,8 @@ MonoBehaviour:
     m_VRangeLocked: 0
     hZoomLockedByDefault: 0
     vZoomLockedByDefault: 0
-    m_HBaseRangeMin: -337.3333
-    m_HBaseRangeMax: 337.3333
+    m_HBaseRangeMin: -338.3333
+    m_HBaseRangeMax: 338.3333
     m_VBaseRangeMin: -101.999985
     m_VBaseRangeMax: 101.999985
     m_HAllowExceedBaseRangeMin: 1
@@ -425,23 +425,23 @@ MonoBehaviour:
       serializedVersion: 2
       x: 0
       y: 21
-      width: 674.6666
+      width: 676.6666
       height: 203.99997
     m_Scale: {x: 1, y: 1}
-    m_Translation: {x: 337.3333, y: 101.999985}
+    m_Translation: {x: 338.3333, y: 101.999985}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -337.3333
+      x: -338.3333
       y: -101.999985
-      width: 674.6666
+      width: 676.6666
       height: 203.99997
     m_MinimalGUI: 1
   m_defaultScale: 1
-  m_LastWindowPixelSize: {x: 1011.99994, y: 337.49994}
+  m_LastWindowPixelSize: {x: 1014.99994, y: 337.49994}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
   m_LowResolutionForAspectRatios: 00000000000000000000
@@ -469,7 +469,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 72.66667
-    width: 165.66667
+    width: 165
     height: 269
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -503,7 +503,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 48690000
     m_LastClickedID: 26952
-    m_ExpandedIDs: 00000000f4620000f6620000
+    m_ExpandedIDs: 00000000f8620000fa620000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -531,7 +531,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 60}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: ffffffff00000000f4620000f6620000
+    m_ExpandedIDs: ffffffff00000000f8620000fa620000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -607,9 +607,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 166.66667
+    x: 166
     y: 72.66667
-    width: 179.33333
+    width: 178
     height: 269
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -620,7 +620,7 @@ MonoBehaviour:
       scrollPos: {x: 0, y: 0}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: e2f9ffff24fbffff
+      m_ExpandedIDs: 24fbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -666,7 +666,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 362.6667
-    width: 347
+    width: 345
     height: 268.3333
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -692,9 +692,9 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 348
+    x: 346
     y: 72.66667
-    width: 674.6666
+    width: 676.6666
     height: 312.33334
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
@@ -919,9 +919,9 @@ MonoBehaviour:
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_Position:
-    m_Target: {x: -0.7963714, y: 0.030088056, z: -0.012764094}
+    m_Target: {x: -0.8583489, y: 0.18521734, z: -0.011171971}
     speed: 2
-    m_Value: {x: -0.7963714, y: 0.030088056, z: -0.012764094}
+    m_Value: {x: -0.8583489, y: 0.18521734, z: -0.011171971}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -972,9 +972,9 @@ MonoBehaviour:
     speed: 2
     m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 3.5380342
+    m_Target: 3.3788226
     speed: 2
-    m_Value: 3.5380342
+    m_Value: 3.3788226
   m_Ortho:
     m_Target: 1
     speed: 2


### PR DESCRIPTION
Fixed a bug where the player may still move inside a tile.

Removed reliance on Unity's built-in collision2D detection function, since it does not serve its purpose in our game well. Rather, it is replaced with another function to detect a change in the object occupying the tiles in TileManager.