### PR TITLE
Fixed bug where heavy tile gives error when empty

### DIFF
--- a/Food boy saves the kitchen/Assets/Scripts/Coordinator.cs
+++ b/Food boy saves the kitchen/Assets/Scripts/Coordinator.cs
@@ -356,7 +356,8 @@ public class Coordinator : MonoBehaviour
         Dictionary<string, bool> heavyTags = new();
         foreach (TileManager tile in heavyTiles)
         {
-            heavyTags.Add(tile.colFoodTag(), true);
+            if (!String.IsNullOrEmpty(tile.colFoodTag()))
+                heavyTags.Add(tile.colFoodTag(), true);
         }
 
         foreach (Tags obj in objWithTag)

--- a/Food boy saves the kitchen/UserSettings/EditorUserSettings.asset
+++ b/Food boy saves the kitchen/UserSettings/EditorUserSettings.asset
@@ -6,34 +6,34 @@ EditorUserSettings:
   serializedVersion: 4
   m_ConfigSettings:
     RecentlyUsedSceneGuid-0:
-      value: 5b50525e5d065f0c090f0a2711705c4412161c7c792b7e68747b4e6bb6b4366f
-      flags: 0
-    RecentlyUsedSceneGuid-1:
       value: 02530c5e5d060d085c0b0d75417507444f16482b7a782263752d4d31b1b6646e
       flags: 0
-    RecentlyUsedSceneGuid-2:
+    RecentlyUsedSceneGuid-1:
       value: 0500510507015e0a08595f7748225e44474f4e7b7d7b7f692c2f4f31e3e3623a
       flags: 0
-    RecentlyUsedSceneGuid-3:
+    RecentlyUsedSceneGuid-2:
       value: 0752515054070a5e090a597144730c44104f1a7d742c25337c71486ab7b0376e
       flags: 0
-    RecentlyUsedSceneGuid-4:
+    RecentlyUsedSceneGuid-3:
       value: 57010657000458025f5a552646740e4446164a297a2c7e6278704837b1b56d61
       flags: 0
-    RecentlyUsedSceneGuid-5:
+    RecentlyUsedSceneGuid-4:
       value: 51540c0003000f020b080927467a0644471640287e7072332b7e1865bab7636b
       flags: 0
-    RecentlyUsedSceneGuid-6:
+    RecentlyUsedSceneGuid-5:
       value: 50070d535c07515e0b580f2011705944124e4d78297e23337a7f1865b7b23139
       flags: 0
-    RecentlyUsedSceneGuid-7:
+    RecentlyUsedSceneGuid-6:
       value: 0753070253530b585f585876117607444e15497e2e7076642f7c4562e3b9363e
       flags: 0
-    RecentlyUsedSceneGuid-8:
+    RecentlyUsedSceneGuid-7:
       value: 0557050050505d0c595b0d77432008444e15487f2d2b25652b2c4f63b0b5676d
       flags: 0
-    RecentlyUsedSceneGuid-9:
+    RecentlyUsedSceneGuid-8:
       value: 540151075502510f580b5f2745745d4414151d792d7f2035752f1e32e7b2633c
+      flags: 0
+    RecentlyUsedSceneGuid-9:
+      value: 5605025500035e5d0f0c5b2015210b4410151c782a7a733575794f62b7e26439
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650


### PR DESCRIPTION
Fixed a small bug related to heavy tiles giving an error when there is no object on top of it.