### PR TITLE
Cut interaction with you tile bug fix

### DIFF
--- a/Food boy saves the kitchen/Assets/Scenes/Levels/Level17.unity
+++ b/Food boy saves the kitchen/Assets/Scenes/Levels/Level17.unity
@@ -509,6 +509,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: Knife (1)
       objectReference: {fileID: 0}
+    - target: {fileID: 4448616405915179234, guid: d2d70d04ef4eaf14495dd284562acc7c, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 4448616405915179242, guid: d2d70d04ef4eaf14495dd284562acc7c, type: 3}
       propertyPath: m_RootOrder
       value: 4

--- a/Food boy saves the kitchen/Assets/Scripts/YouManager.cs
+++ b/Food boy saves the kitchen/Assets/Scripts/YouManager.cs
@@ -38,10 +38,9 @@ public class YouManager : TileManager
         //and abandon them (exclude from foodSameTag)
         if (col)
         {
-            bool colCut = col.GetComponent<Tags>().isCut();
             if (!col.GetComponent<Tags>().isKnife())
             {
-                foodSameTag.FindAll(food => food.GetComponent<Tags>().isCut() != colCut)
+                foodSameTag.FindAll(food => food.GetComponent<Tags>().isCut())
                 .ForEach(food =>
                 {
                     food.GetComponent<DetachChildren>().detachAllChildren();

--- a/Food boy saves the kitchen/UserSettings/EditorUserSettings.asset
+++ b/Food boy saves the kitchen/UserSettings/EditorUserSettings.asset
@@ -6,34 +6,34 @@ EditorUserSettings:
   serializedVersion: 4
   m_ConfigSettings:
     RecentlyUsedSceneGuid-0:
-      value: 0752515054070a5e090a597144730c44104f1a7d742c25337c71486ab7b0376e
-      flags: 0
-    RecentlyUsedSceneGuid-1:
-      value: 57010657000458025f5a552646740e4446164a297a2c7e6278704837b1b56d61
-      flags: 0
-    RecentlyUsedSceneGuid-2:
       value: 51540c0003000f020b080927467a0644471640287e7072332b7e1865bab7636b
       flags: 0
-    RecentlyUsedSceneGuid-3:
-      value: 50070d535c07515e0b580f2011705944124e4d78297e23337a7f1865b7b23139
-      flags: 0
-    RecentlyUsedSceneGuid-4:
-      value: 0753070253530b585f585876117607444e15497e2e7076642f7c4562e3b9363e
-      flags: 0
-    RecentlyUsedSceneGuid-5:
-      value: 0557050050505d0c595b0d77432008444e15487f2d2b25652b2c4f63b0b5676d
-      flags: 0
-    RecentlyUsedSceneGuid-6:
+    RecentlyUsedSceneGuid-1:
       value: 540151075502510f580b5f2745745d4414151d792d7f2035752f1e32e7b2633c
       flags: 0
-    RecentlyUsedSceneGuid-7:
+    RecentlyUsedSceneGuid-2:
       value: 5605025500035e5d0f0c5b2015210b4410151c782a7a733575794f62b7e26439
+      flags: 0
+    RecentlyUsedSceneGuid-3:
+      value: 5b50525e5d065f0c090f0a2711705c4412161c7c792b7e68747b4e6bb6b4366f
+      flags: 0
+    RecentlyUsedSceneGuid-4:
+      value: 55540c5f55515e5e5d5c0d2112255a4444154f7d282b74622e7f4563b3b3676f
+      flags: 0
+    RecentlyUsedSceneGuid-5:
+      value: 5a01555f00560c0e5d5e097711275d44404e4e2f2e7d22622f2c4466b4e56c69
+      flags: 0
+    RecentlyUsedSceneGuid-6:
+      value: 0557050050505d0c595b0d77432008444e15487f2d2b25652b2c4f63b0b5676d
+      flags: 0
+    RecentlyUsedSceneGuid-7:
+      value: 50070d535c07515e0b580f2011705944124e4d78297e23337a7f1865b7b23139
       flags: 0
     RecentlyUsedSceneGuid-8:
       value: 0500510507015e0a08595f7748225e44474f4e7b7d7b7f692c2f4f31e3e3623a
       flags: 0
     RecentlyUsedSceneGuid-9:
-      value: 5b50525e5d065f0c090f0a2711705c4412161c7c792b7e68747b4e6bb6b4366f
+      value: 0753070253530b585f585876117607444e15497e2e7076642f7c4562e3b9363e
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650

--- a/Food boy saves the kitchen/UserSettings/Layouts/default-2021.dwlt
+++ b/Food boy saves the kitchen/UserSettings/Layouts/default-2021.dwlt
@@ -45,7 +45,7 @@ MonoBehaviour:
     x: 0
     y: 0
     width: 1280
-    height: 629.3334
+    height: 629.3333
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
   m_UseTopView: 1
@@ -90,7 +90,7 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 609.3334
+    y: 609.3333
     width: 1280
     height: 20
   m_MinSize: {x: 0, y: 0}
@@ -116,11 +116,11 @@ MonoBehaviour:
     x: 0
     y: 30
     width: 1280
-    height: 579.3334
+    height: 579.3333
   m_MinSize: {x: 400, y: 200}
   m_MaxSize: {x: 32384, y: 16192}
   vertical: 0
-  controlID: 52
+  controlID: 105
 --- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -141,11 +141,11 @@ MonoBehaviour:
     x: 0
     y: 0
     width: 295.33334
-    height: 579.3334
+    height: 579.3333
   m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 58
+  controlID: 21
 --- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -170,7 +170,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 59
+  controlID: 22
 --- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -241,7 +241,7 @@ MonoBehaviour:
     x: 0
     y: 306
     width: 295.33334
-    height: 273.33337
+    height: 273.3333
   m_MinSize: {x: 101, y: 121}
   m_MaxSize: {x: 4001, y: 4021}
   m_ActualView: {fileID: 18}
@@ -269,11 +269,11 @@ MonoBehaviour:
     x: 295.33334
     y: 0
     width: 728
-    height: 579.3334
+    height: 579.3333
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 157
+  controlID: 106
 --- !u!114 &12
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -318,7 +318,7 @@ MonoBehaviour:
     x: 0
     y: 336
     width: 728
-    height: 243.33337
+    height: 243.33331
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
   m_ActualView: {fileID: 15}
@@ -345,9 +345,9 @@ MonoBehaviour:
     x: 1023.3333
     y: 0
     width: 256.6667
-    height: 579.3334
-  m_MinSize: {x: 276, y: 121}
-  m_MaxSize: {x: 4001, y: 4021}
+    height: 579.3333
+  m_MinSize: {x: 275, y: 100}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 21}
   m_Panes:
   - {fileID: 21}
@@ -376,7 +376,7 @@ MonoBehaviour:
     x: 295.33334
     y: 408.6667
     width: 726
-    height: 222.33337
+    height: 222.33331
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -426,22 +426,22 @@ MonoBehaviour:
       x: 0
       y: 21
       width: 726
-      height: 201.33337
-    m_Scale: {x: 0.27962968, y: 0.27962968}
-    m_Translation: {x: 363, y: 100.66669}
+      height: 201.33331
+    m_Scale: {x: 0.2796296, y: 0.2796296}
+    m_Translation: {x: 363, y: 100.66666}
     m_MarginLeft: 0
     m_MarginRight: 0
     m_MarginTop: 0
     m_MarginBottom: 0
     m_LastShownAreaInsideMargins:
       serializedVersion: 2
-      x: -1298.1455
-      y: -360
-      width: 2596.291
-      height: 720
+      x: -1298.1459
+      y: -360.00003
+      width: 2596.2917
+      height: 720.00006
     m_MinimalGUI: 1
-  m_defaultScale: 0.27962968
-  m_LastWindowPixelSize: {x: 1089, y: 333.50006}
+  m_defaultScale: 0.2796296
+  m_LastWindowPixelSize: {x: 1089, y: 333.49997}
   m_ClearInEditMode: 1
   m_NoCameraWarning: 1
   m_LowResolutionForAspectRatios: 01000000000000000000
@@ -528,24 +528,24 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_AssetTreeState:
-    scrollPos: {x: 0, y: 496.33337}
+    scrollPos: {x: 0, y: 60}
     m_SelectedIDs: 
     m_LastClickedID: 0
     m_ExpandedIDs: ffffffff000000009c6200009e620000a0620000a2620000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
-      m_Name: 
-      m_OriginalName: 
+      m_Name: Level16
+      m_OriginalName: Level16
       m_EditFieldRect:
         serializedVersion: 2
         x: 0
         y: 0
         width: 0
         height: 0
-      m_UserData: 0
+      m_UserData: 25402
       m_IsWaitingForDelay: 0
       m_IsRenaming: 0
-      m_OriginalEventType: 11
+      m_OriginalEventType: 0
       m_IsRenamingFilename: 1
       m_ClientGUIView: {fileID: 8}
     m_SearchString: 
@@ -618,9 +618,9 @@ MonoBehaviour:
   m_SceneHierarchy:
     m_TreeViewState:
       scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: 26faffff
-      m_LastClickedID: -1498
-      m_ExpandedIDs: 2cfbffff
+      m_SelectedIDs: 54eaffff
+      m_LastClickedID: -5548
+      m_ExpandedIDs: 04ebffff82ecffff7aeeffff36f0fffff2f1ffff5af2ffff5ef5ffff2cfbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -667,7 +667,7 @@ MonoBehaviour:
     x: 0
     y: 378.6667
     width: 294.33334
-    height: 252.33337
+    height: 252.33331
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -1057,7 +1057,7 @@ MonoBehaviour:
     x: 1023.3334
     y: 72.66667
     width: 255.66669
-    height: 558.3334
+    height: 558.3333
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default


### PR DESCRIPTION
Fixed a bug where a cut object on a you tile will only control cut objects elsewhere. Instead, modified it to make cut objects only control non-cut objects elsewhere.